### PR TITLE
fix NoSuchMethodError in filter

### DIFF
--- a/lib/formatter/filter.dart
+++ b/lib/formatter/filter.dart
@@ -189,6 +189,9 @@ class Filter implements Function {
   }
 
   List call(List items, var expression, [var comparator]) {
+    if (items == null) {
+      return const [];
+    }
     if (expression == null) {
       return items.toList(growable: false); // Missing expression → passthrough.
     } else if (expression is! Map && expression is! Function &&


### PR DESCRIPTION
I got errors when using `filter` for objects that is nullable.
I seem to be no substantial problem.
However, I want to suppress unwanted errors.

```
The null object does not have a method 'toList'.

NoSuchMethodError: method not found: 'toList'
Receiver: null
Arguments: [growable: false]

STACKTRACE:
#0      Object.noSuchMethod (dart:core-patch/object_patch.dart:45)
#1      Filter.call (package:angular/formatter/filter.dart:193:26)
...
```
